### PR TITLE
🚀 Fix: Stuck character detection and recovery for pedestrian simulation

### DIFF
--- a/costnav_isaacsim/launch.py
+++ b/costnav_isaacsim/launch.py
@@ -289,6 +289,11 @@ class CostNavSimLauncher:
         if mission_manager is not None:
             mission_manager.step()
 
+        # Update people manager for stuck detection/recovery (lightweight, self-throttled)
+        if self.people_manager is not None:
+            current_time = self.simulation_context.current_time
+            self.people_manager.update(current_time)
+
         if throttle:
             elapsed = time.perf_counter() - tick_start
             sleep_duration = self.rendering_dt - elapsed


### PR DESCRIPTION
## 🎯 Purpose
- [x] New feature implementation
- [x] Bug fix
- [ ] Experimental code
- [ ] Documentation/configuration update
- [ ] Refactoring

## 📊 Changes

Implements lightweight stuck detection and automatic recovery for simulated pedestrians who become idle during navigation.

### Key additions:

**`CharacterStuckTracker` class** - Lightweight position-based tracking
- Tracks character positions over time without NavMesh API calls
- Configurable stuck threshold (default: 10s) and recovery cooldown (default: 30s)
- Uses simple distance calculations for movement detection
- Maintains recovery statistics for monitoring

**`PeopleManager` enhancements:**
- `update(current_time)` - Self-throttling periodic check (every 2s)
- `_get_character_position()` - Reads prim transforms directly (no NavMesh queries)
- `_recover_stuck_character()` - Two-tier recovery strategy:
  1. Primary: Clear command queue → forces behavior script regeneration
  2. Fallback: Re-apply behavior script if primary fails
- `get_stuck_detection_stats()` - Recovery monitoring API

**Files modified:**
- `costnav_isaacsim/people_manager.py` (+342 lines)
- `costnav_isaacsim/launch.py` (+5 lines)

### Performance considerations:
- ✅ Zero NavMesh API calls during detection/recovery
- ✅ Position reading via cached SkelRoot prims
- ✅ Self-throttled updates (2s intervals, not per-frame)
- ✅ Recovery uses pre-cached NavMesh positions from behavior scripts

## 🧪 Testing
- [ ] Verified locally
- [ ] Existing experiments reproducible
- [ ] New test cases added

## 🤔 Review Focus
Specific areas where feedback is needed:
- **Recovery timing**: Are 10s stuck threshold and 30s cooldown appropriate?
- **Performance**: Confirm no FPS impact from position tracking
- **Edge cases**: Characters at NavMesh boundaries or disconnected regions