### PR TITLE
🔥 Add: Nav2 and Teleop evaluation system with mission result tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-isaac-sim build-isaac-lab build-dev build-all build-ros-ws build-ros2 run-ros2 run-isaac-sim run-nav2 run-teleop start-mission start-mission-record run-rosbag stop-rosbag
+.PHONY: build-isaac-sim build-isaac-lab build-dev build-all build-ros-ws build-ros2 run-ros2 run-isaac-sim run-nav2 run-teleop start-mission start-mission-record run-rosbag stop-rosbag run-eval-nav2 run-eval-teleop
 
 DOCKERFILE ?= Dockerfile
 DOCKER_BUILD ?= docker build
@@ -125,3 +125,51 @@ run-rosbag:
 stop-rosbag:
 	$(DOCKER_COMPOSE) --profile rosbag down
 	@echo "ROS bag recording stopped. Check ./rosbags/ for recorded bag files."
+
+# =============================================================================
+# Nav2 Evaluation Targets
+# =============================================================================
+
+# Default evaluation parameters
+TIMEOUT ?= 20
+NUM_MISSIONS ?= 10
+
+# Run Nav2 evaluation (requires running nav2 instance via make run-nav2)
+# Usage: make run-eval-nav2 TIMEOUT=20 NUM_MISSIONS=10
+# Output: ./logs/nav2_evaluation_<timestamp>.log
+run-eval-nav2:
+	@if ! docker ps --format '{{.Names}}' | grep -qx "costnav-ros2-nav2"; then \
+		echo "ERROR: 'make run-nav2' is not running."; \
+		echo ""; \
+		echo "Please start nav2 first in a separate terminal:"; \
+		echo "  make run-nav2"; \
+		echo ""; \
+		echo "Then run this command again:"; \
+		echo "  make run-eval-nav2 TIMEOUT=$(TIMEOUT) NUM_MISSIONS=$(NUM_MISSIONS)"; \
+		exit 1; \
+	fi
+	@echo "Starting Nav2 evaluation..."
+	@echo "  Timeout per mission: $(TIMEOUT)s"
+	@echo "  Number of missions:  $(NUM_MISSIONS)"
+	@echo ""
+	@bash scripts/eval_nav2.sh $(TIMEOUT) $(NUM_MISSIONS)
+
+# Run Teleop evaluation (requires running teleop instance via make run-teleop)
+# Usage: make run-eval-teleop TIMEOUT=20 NUM_MISSIONS=10
+# Output: ./logs/teleop_evaluation_<timestamp>.log
+run-eval-teleop:
+	@if ! docker ps --format '{{.Names}}' | grep -qx "costnav-ros2-teleop"; then \
+		echo "ERROR: 'make run-teleop' is not running."; \
+		echo ""; \
+		echo "Please start teleop first in a separate terminal:"; \
+		echo "  make run-teleop"; \
+		echo ""; \
+		echo "Then run this command again:"; \
+		echo "  make run-eval-teleop TIMEOUT=$(TIMEOUT) NUM_MISSIONS=$(NUM_MISSIONS)"; \
+		exit 1; \
+	fi
+	@echo "Starting Teleop evaluation..."
+	@echo "  Timeout per mission: $(TIMEOUT)s"
+	@echo "  Number of missions:  $(NUM_MISSIONS)"
+	@echo ""
+	@bash scripts/eval_teleop.sh $(TIMEOUT) $(NUM_MISSIONS)

--- a/costnav_isaacsim/config/config_loader.py
+++ b/costnav_isaacsim/config/config_loader.py
@@ -63,6 +63,7 @@ class MissionConfig:
 
     # Mission execution
     timeout: float = 3600.0  # 1 hour
+    goal_tolerance: float = 1.0  # Distance to goal for success (meters)
 
     # Distance constraints
     min_distance: float = 5.0
@@ -126,6 +127,7 @@ class MissionConfig:
 
         return cls(
             timeout=mission_data.get("timeout", 3600.0),
+            goal_tolerance=mission_data.get("goal_tolerance", 1.0),
             min_distance=distance_data.get("min", 5.0),
             max_distance=distance_data.get("max", 50.0),
             nav2=nav2_config,

--- a/costnav_isaacsim/config/mission_config.yaml
+++ b/costnav_isaacsim/config/mission_config.yaml
@@ -9,7 +9,7 @@
 mission:
 
   # Mission timeout (seconds)
-  timeout: 3600.0  # 1 hour
+  timeout: null  # No timeout (use a float number like 3600.0 for 1 hour)
 
 # Distance constraints for start/goal sampling (in meters)
 distance:

--- a/costnav_isaacsim/nav2_mission/mission_manager.py
+++ b/costnav_isaacsim/nav2_mission/mission_manager.py
@@ -356,6 +356,11 @@ class MissionManager:
             response.message = "Missions already completed."
             return response
 
+        # Reset mission result immediately to prevent race condition
+        # where the eval script sees the previous mission's SUCCESS result
+        self._last_mission_result = MissionResult.PENDING
+        self._last_mission_distance = None
+
         self._start_requested = True
         if self._is_mission_active():
             self._restart_requested = True

--- a/costnav_isaacsim/nav2_mission/mission_manager.py
+++ b/costnav_isaacsim/nav2_mission/mission_manager.py
@@ -300,9 +300,7 @@ class MissionManager:
             logger.info(
                 f"[{self._state.name}] Distance range: {self.config.min_distance}m - {self.config.max_distance}m"
             )
-            logger.info(
-                f"[{self._state.name}] Goal tolerance: {self.mission_config.goal_tolerance}m"
-            )
+            logger.info(f"[{self._state.name}] Goal tolerance: {self.mission_config.goal_tolerance}m")
 
         except Exception as e:
             logger.error(f"[{self._state.name}] Failed to initialize mission manager: {e}")

--- a/costnav_isaacsim/nav2_mission/mission_manager.py
+++ b/costnav_isaacsim/nav2_mission/mission_manager.py
@@ -625,11 +625,12 @@ class MissionManager:
     def _step_waiting_for_completion(self):
         """Wait for mission timeout before returning to wait-for-start."""
         elapsed = self._get_current_time_seconds() - self._mission_start_time
-        if elapsed >= self.mission_config.timeout:
-            self._state = MissionState.WAITING_FOR_START
-            logger.info(
-                f"[{self._state.name}] Mission {self._current_mission} timed out {self.mission_config.timeout=}, waiting for start signal"
-            )
+        if self.mission_config.timeout is not None:
+            if elapsed >= self.mission_config.timeout:
+                self._state = MissionState.WAITING_FOR_START
+                logger.info(
+                    f"[{self._state.name}] Mission {self._current_mission} timed out {self.mission_config.timeout=}, waiting for start signal"
+                )
 
     def _cleanup(self):
         """Clean up ROS2 resources."""

--- a/costnav_isaacsim/nav2_mission/mission_manager.py
+++ b/costnav_isaacsim/nav2_mission/mission_manager.py
@@ -57,6 +57,14 @@ class MissionState(Enum):
     COMPLETED = "completed"
 
 
+class MissionResult(Enum):
+    """Result of a mission execution."""
+
+    PENDING = "pending"  # Mission not yet started or in progress
+    SUCCESS = "success"  # Robot reached goal within tolerance
+    FAILURE = "failure"  # Timeout reached before reaching goal
+
+
 class MissionManager:
     """Mission manager that runs in the main simulation loop.
 
@@ -134,11 +142,14 @@ class MissionManager:
         self._robot_prim_path = None
         self._executor = None
         self._start_service = None
+        self._result_service = None
+        self._odom_sub = None
 
         # State machine
         self._state = MissionState.INIT
         self._current_mission = 0
         self._mission_start_time = None
+        self._mission_end_time = None
         self._wait_start_time = None
         self._settle_steps_remaining = 0
         self._initialized = False
@@ -148,6 +159,13 @@ class MissionManager:
         # Current mission positions
         self._current_start = None
         self._current_goal = None
+
+        # Robot position tracking (from odom)
+        self._robot_position = None  # (x, y, z) tuple
+
+        # Mission result tracking
+        self._last_mission_result = MissionResult.PENDING
+        self._last_mission_distance = None  # Distance to goal at end
 
     def _get_current_time_seconds(self) -> float:
         """Get current time in seconds from ROS clock.
@@ -196,10 +214,12 @@ class MissionManager:
         import rclpy
         from rclpy.executors import SingleThreadedExecutor
         from geometry_msgs.msg import PoseStamped, PoseWithCovarianceStamped
+        from nav_msgs.msg import Odometry
         from rclpy.node import Node
         from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
         from std_srvs.srv import Trigger
 
+        from .mission_result_srv import GetMissionResult
         from .marker_publisher import MarkerPublisher
         from .navmesh_sampler import NavMeshSampler
 
@@ -212,6 +232,11 @@ class MissionManager:
 
             # Start mission service (manual trigger)
             self._start_service = self._node.create_service(Trigger, "/start_mission", self._handle_start_mission)
+
+            # Mission result service
+            self._result_service = self._node.create_service(
+                GetMissionResult, "/get_mission_result", self._handle_get_mission_result
+            )
 
             # Initialize NavMesh sampler with config values
             self._sampler = NavMeshSampler(
@@ -262,6 +287,11 @@ class MissionManager:
                 PoseStamped, self.mission_config.nav2.goal_pose_topic, pose_qos
             )
 
+            # Subscribe to odometry for robot position tracking
+            self._odom_sub = self._node.create_subscription(
+                Odometry, self.mission_config.nav2.odom_topic, self._odom_callback, 10
+            )
+
             self._initialized = True
             self._state = MissionState.WAITING_FOR_NAV2
             self._wait_start_time = self._get_current_time_seconds()
@@ -269,6 +299,9 @@ class MissionManager:
             logger.info(f"[{self._state.name}] Mission manager initialized")
             logger.info(
                 f"[{self._state.name}] Distance range: {self.config.min_distance}m - {self.config.max_distance}m"
+            )
+            logger.info(
+                f"[{self._state.name}] Goal tolerance: {self.mission_config.goal_tolerance}m"
             )
 
         except Exception as e:
@@ -293,9 +326,30 @@ class MissionManager:
         self._current_start = None
         self._current_goal = None
         self._mission_start_time = None
+        self._mission_end_time = None
         self._settle_steps_remaining = 0
+        self._last_mission_result = MissionResult.PENDING
+        self._last_mission_distance = None
 
-    def _handle_start_mission(self, request, response):
+    def _odom_callback(self, msg) -> None:
+        """Handle odometry messages for robot position tracking."""
+        pos = msg.pose.pose.position
+        self._robot_position = (pos.x, pos.y, pos.z)
+
+    def _get_distance_to_goal(self) -> Optional[float]:
+        """Calculate distance from robot to goal.
+
+        Returns:
+            Distance in meters, or None if positions unknown.
+        """
+        if self._robot_position is None or self._current_goal is None:
+            return None
+
+        rx, ry, _ = self._robot_position
+        gx, gy = self._current_goal.x, self._current_goal.y
+        return math.sqrt((rx - gx) ** 2 + (ry - gy) ** 2)
+
+    def _handle_start_mission(self, _request, response):
         """Handle external mission start trigger."""
         if self._state == MissionState.COMPLETED:
             response.success = False
@@ -314,6 +368,38 @@ class MissionManager:
 
         response.success = True
         response.message = "Mission start requested."
+        return response
+
+    def _handle_get_mission_result(self, _request, response):
+        """Handle mission result query service.
+
+        Returns the result of the last completed mission as JSON in the message field.
+        Response format:
+        {
+            "result": "pending" | "success" | "failure",
+            "mission_number": int,
+            "distance_to_goal": float,
+            "in_progress": bool
+        }
+        """
+        import json
+
+        in_progress = self._state == MissionState.WAITING_FOR_COMPLETION
+        distance = self._last_mission_distance if self._last_mission_distance is not None else -1.0
+
+        if in_progress:
+            current_dist = self._get_distance_to_goal()
+            distance = current_dist if current_dist is not None else -1.0
+
+        result_data = {
+            "result": self._last_mission_result.value,
+            "mission_number": self._current_mission,
+            "distance_to_goal": distance,
+            "in_progress": in_progress,
+        }
+
+        response.success = True
+        response.message = json.dumps(result_data)
         return response
 
     def _spin_ros_once(self) -> None:
@@ -623,14 +709,38 @@ class MissionManager:
             self._state = MissionState.WAITING_FOR_COMPLETION
 
     def _step_waiting_for_completion(self):
-        """Wait for mission timeout before returning to wait-for-start."""
+        """Wait for goal completion or timeout.
+
+        Success: Robot within goal_tolerance of goal position.
+        Failure: Timeout reached before reaching goal.
+        """
         elapsed = self._get_current_time_seconds() - self._mission_start_time
-        if self.mission_config.timeout is not None:
-            if elapsed >= self.mission_config.timeout:
-                self._state = MissionState.WAITING_FOR_START
-                logger.info(
-                    f"[{self._state.name}] Mission {self._current_mission} timed out {self.mission_config.timeout=}, waiting for start signal"
-                )
+        distance = self._get_distance_to_goal()
+
+        # Check for goal completion (success)
+        if distance is not None and distance <= self.mission_config.goal_tolerance:
+            self._mission_end_time = self._get_current_time_seconds()
+            self._last_mission_result = MissionResult.SUCCESS
+            self._last_mission_distance = distance
+            self._state = MissionState.WAITING_FOR_START
+            logger.info(
+                f"[SUCCESS] Mission {self._current_mission} completed! "
+                f"Distance to goal: {distance:.2f}m (tolerance: {self.mission_config.goal_tolerance}m), "
+                f"elapsed: {elapsed:.1f}s"
+            )
+            return
+
+        # Check for timeout (failure)
+        if self.mission_config.timeout is not None and elapsed >= self.mission_config.timeout:
+            self._mission_end_time = self._get_current_time_seconds()
+            self._last_mission_result = MissionResult.FAILURE
+            self._last_mission_distance = distance if distance is not None else -1.0
+            self._state = MissionState.WAITING_FOR_START
+            logger.info(
+                f"[FAILURE] Mission {self._current_mission} timed out! "
+                f"Distance to goal: {distance:.2f}m (needed: {self.mission_config.goal_tolerance}m), "
+                f"timeout: {self.mission_config.timeout}s"
+            )
 
     def _cleanup(self):
         """Clean up ROS2 resources."""

--- a/costnav_isaacsim/nav2_mission/mission_result_srv.py
+++ b/costnav_isaacsim/nav2_mission/mission_result_srv.py
@@ -17,4 +17,3 @@ from std_srvs.srv import Trigger
 
 # Re-export Trigger as GetMissionResult for cleaner imports
 GetMissionResult = Trigger
-

--- a/costnav_isaacsim/nav2_mission/mission_result_srv.py
+++ b/costnav_isaacsim/nav2_mission/mission_result_srv.py
@@ -1,0 +1,20 @@
+"""Service wrapper for mission result queries using std_srvs/Trigger.
+
+Since custom ROS2 service definitions require a full package build,
+we use std_srvs/srv/Trigger and encode the mission result as JSON
+in the response message field.
+
+Response format (JSON in message field):
+{
+    "result": "pending" | "success" | "failure",
+    "mission_number": int,
+    "distance_to_goal": float,
+    "in_progress": bool
+}
+"""
+
+from std_srvs.srv import Trigger
+
+# Re-export Trigger as GetMissionResult for cleaner imports
+GetMissionResult = Trigger
+

--- a/scripts/eval_nav2.sh
+++ b/scripts/eval_nav2.sh
@@ -1,0 +1,289 @@
+#!/bin/bash
+# Nav2 Evaluation Script
+# Runs consecutive missions and generates comprehensive evaluation logs
+#
+# Usage: ./eval_nav2.sh [TIMEOUT] [NUM_MISSIONS]
+#   TIMEOUT: Mission timeout in seconds (default: 20)
+#   NUM_MISSIONS: Number of missions to run (default: 10)
+#
+# Requires: A running nav2 instance (make run-nav2)
+
+set -e
+
+# Configuration
+TIMEOUT="${1:-20}"
+NUM_MISSIONS="${2:-10}"
+CONTAINER=""
+LOG_DIR="${LOG_DIR:-./logs}"
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+LOG_FILE="${LOG_DIR}/nav2_evaluation_${TIMESTAMP}.log"
+
+# Statistics tracking
+SUCCESSFUL=0
+FAILED=0
+declare -a MISSION_RESULTS
+declare -a MISSION_START_TIMES
+declare -a MISSION_END_TIMES
+declare -a MISSION_ERRORS
+
+# Find the running nav2 container (strictly requires costnav-ros2-nav2)
+find_container() {
+    if docker ps --format '{{.Names}}' | grep -qx "costnav-ros2-nav2"; then
+        CONTAINER="costnav-ros2-nav2"
+        return 0
+    fi
+    return 1
+}
+
+# Log to both console and file
+log() {
+    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+    echo "$msg"
+    echo "$msg" >> "$LOG_FILE"
+}
+
+# Log only to file
+log_file() {
+    echo "$1" >> "$LOG_FILE"
+}
+
+# Execute ROS2 command in container
+ros2_exec() {
+    docker exec "$CONTAINER" bash -c "
+        if [ -f /opt/ros/jazzy/setup.bash ]; then source /opt/ros/jazzy/setup.bash; fi;
+        if [ -f /workspace/build_ws/install/local_setup.sh ]; then source /workspace/build_ws/install/local_setup.sh; fi;
+        if [ -f /isaac-sim/setup_ros_env.sh ]; then source /isaac-sim/setup_ros_env.sh; fi;
+        $1
+    " 2>&1
+}
+
+# Call start_mission service and wait for response
+start_mission() {
+    local result
+    result=$(ros2_exec "ros2 service call /start_mission std_srvs/srv/Trigger {}")
+    echo "$result"
+}
+
+# Query mission result from /get_mission_result service
+get_mission_result() {
+    local result
+    result=$(ros2_exec "ros2 service call /get_mission_result std_srvs/srv/Trigger {}")
+    echo "$result"
+}
+
+# Parse JSON field from mission result response
+# Usage: parse_result_field "result_string" "field_name"
+parse_result_field() {
+    local result_str="$1"
+    local field="$2"
+    # Extract the message field which contains JSON
+    local json_str
+    json_str=$(echo "$result_str" | grep -oP "message='[^']*'" | sed "s/message='//;s/'$//")
+    # Parse the specific field from JSON
+    echo "$json_str" | grep -oP "\"$field\":\s*[^,}]+" | sed "s/\"$field\":\s*//" | tr -d '"'
+}
+
+# Run a single mission with timeout and result checking
+run_mission() {
+    local mission_num=$1
+    local start_time
+    local end_time
+    local duration
+    local error_msg=""
+    local mission_result="FAILED"
+    local distance_to_goal=""
+
+    start_time=$(date +%s.%N)
+    MISSION_START_TIMES[$mission_num]=$(date '+%Y-%m-%d %H:%M:%S.%3N')
+
+    log "Mission $mission_num/$NUM_MISSIONS: Starting (timeout: ${TIMEOUT}s)"
+
+    # Call start_mission service
+    local service_result
+    service_result=$(start_mission 2>&1)
+
+    if echo "$service_result" | grep -q "success=True"; then
+        log "Mission $mission_num: Started, monitoring for completion..."
+
+        # Poll for mission completion or timeout
+        local poll_interval=1
+        local elapsed=0
+        local result_status="pending"
+
+        while [ "$elapsed" -lt "$TIMEOUT" ]; do
+            sleep "$poll_interval"
+            elapsed=$((elapsed + poll_interval))
+
+            # Query mission result
+            local result_response
+            result_response=$(get_mission_result 2>&1)
+
+            result_status=$(parse_result_field "$result_response" "result")
+            local in_progress
+            in_progress=$(parse_result_field "$result_response" "in_progress")
+            distance_to_goal=$(parse_result_field "$result_response" "distance_to_goal")
+
+            # Check if mission completed (success or failure)
+            if [ "$result_status" = "success" ]; then
+                mission_result="SUCCESS"
+                log "Mission $mission_num: Goal reached! Distance: ${distance_to_goal}m"
+                break
+            elif [ "$result_status" = "failure" ]; then
+                mission_result="FAILED"
+                error_msg="Timeout - distance to goal: ${distance_to_goal}m"
+                log "Mission $mission_num: Timeout! Distance: ${distance_to_goal}m"
+                break
+            fi
+
+            # Log progress every 5 seconds
+            if [ $((elapsed % 5)) -eq 0 ]; then
+                log "Mission $mission_num: In progress... (${elapsed}s elapsed, distance_to_goal: ${distance_to_goal}m)"
+            fi
+        done
+
+        # If we exited the loop due to our timeout (not mission manager's), mark as failed
+        if [ "$result_status" = "pending" ]; then
+            mission_result="FAILED"
+            error_msg="Evaluation timeout reached"
+            log "Mission $mission_num: Evaluation timeout!"
+        fi
+    else
+        error_msg="Service call failed: $service_result"
+        log "Mission $mission_num: ERROR - $error_msg"
+    fi
+
+    end_time=$(date +%s.%N)
+    MISSION_END_TIMES[$mission_num]=$(date '+%Y-%m-%d %H:%M:%S.%3N')
+
+    duration=$(echo "$end_time - $start_time" | bc)
+
+    if [ "$mission_result" = "SUCCESS" ]; then
+        SUCCESSFUL=$((SUCCESSFUL + 1))
+        MISSION_RESULTS[$mission_num]="SUCCESS"
+        log "Mission $mission_num: SUCCESS (duration: ${duration}s, distance: ${distance_to_goal}m)"
+    else
+        FAILED=$((FAILED + 1))
+        MISSION_RESULTS[$mission_num]="FAILED"
+        MISSION_ERRORS[$mission_num]="$error_msg"
+        log "Mission $mission_num: FAILED (duration: ${duration}s) - $error_msg"
+    fi
+}
+
+# Generate evaluation summary
+generate_summary() {
+    local success_rate
+    if [ "$NUM_MISSIONS" -gt 0 ]; then
+        success_rate=$(echo "scale=2; $SUCCESSFUL * 100 / $NUM_MISSIONS" | bc)
+    else
+        success_rate="0"
+    fi
+
+    log_file ""
+    log_file "============================================================"
+    log_file "NAV2 EVALUATION SUMMARY"
+    log_file "============================================================"
+    log_file "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
+    log_file "Configuration:"
+    log_file "  - Timeout per mission: ${TIMEOUT}s"
+    log_file "  - Total missions: $NUM_MISSIONS"
+    log_file "  - Container: $CONTAINER"
+    log_file ""
+    log_file "Results:"
+    log_file "  - Successful missions: $SUCCESSFUL"
+    log_file "  - Failed missions: $FAILED"
+    log_file "  - Success rate: ${success_rate}%"
+    log_file ""
+    log_file "Per-Mission Results:"
+    log_file "------------------------------------------------------------"
+
+    for i in $(seq 1 $NUM_MISSIONS); do
+        local result="${MISSION_RESULTS[$i]:-N/A}"
+        local start="${MISSION_START_TIMES[$i]:-N/A}"
+        local end="${MISSION_END_TIMES[$i]:-N/A}"
+        local error="${MISSION_ERRORS[$i]:-}"
+
+        log_file "Mission $i:"
+        log_file "  Status: $result"
+        log_file "  Start:  $start"
+        log_file "  End:    $end"
+        if [ -n "$error" ]; then
+            log_file "  Error:  $error"
+        fi
+    done
+
+    log_file "------------------------------------------------------------"
+    log_file "Log file: $LOG_FILE"
+    log_file "============================================================"
+}
+
+# Main execution
+main() {
+    # Create log directory if it doesn't exist
+    mkdir -p "$LOG_DIR"
+
+    # Initialize log file
+    log_file "============================================================"
+    log_file "NAV2 EVALUATION LOG"
+    log_file "Started: $(date '+%Y-%m-%d %H:%M:%S')"
+    log_file "============================================================"
+    log_file ""
+
+    echo ""
+    echo "=============================================="
+    echo "  Nav2 Evaluation Script"
+    echo "=============================================="
+    echo "  Timeout:      ${TIMEOUT}s"
+    echo "  Missions:     $NUM_MISSIONS"
+    echo "  Log file:     $LOG_FILE"
+    echo "=============================================="
+    echo ""
+
+    # Find container (strictly requires make run-nav2)
+    if ! find_container; then
+        log "ERROR: 'make run-nav2' is not running."
+        log "Container 'costnav-ros2-nav2' not found."
+        log ""
+        log "Please start nav2 first in a separate terminal:"
+        log "  make run-nav2"
+        exit 1
+    fi
+
+    log "Using container: $CONTAINER"
+    log ""
+    log "Starting evaluation of $NUM_MISSIONS missions..."
+    log ""
+
+    # Run all missions
+    for i in $(seq 1 $NUM_MISSIONS); do
+        run_mission "$i"
+        # Small delay between missions
+        if [ "$i" -lt "$NUM_MISSIONS" ]; then
+            sleep 2
+        fi
+    done
+
+    # Generate summary
+    generate_summary
+
+    # Print final summary to console
+    local success_rate
+    if [ "$NUM_MISSIONS" -gt 0 ]; then
+        success_rate=$(echo "scale=2; $SUCCESSFUL * 100 / $NUM_MISSIONS" | bc)
+    else
+        success_rate="0"
+    fi
+
+    echo ""
+    echo "=============================================="
+    echo "  Evaluation Complete"
+    echo "=============================================="
+    echo "  Successful: $SUCCESSFUL / $NUM_MISSIONS"
+    echo "  Failed:     $FAILED / $NUM_MISSIONS"
+    echo "  Success Rate: ${success_rate}%"
+    echo "  Log file:   $LOG_FILE"
+    echo "=============================================="
+}
+
+# Run main
+main
+

--- a/scripts/eval_teleop.sh
+++ b/scripts/eval_teleop.sh
@@ -1,0 +1,288 @@
+#!/bin/bash
+# Teleop Evaluation Script
+# Runs consecutive missions and generates comprehensive evaluation logs
+#
+# Usage: ./eval_teleop.sh [TIMEOUT] [NUM_MISSIONS]
+#   TIMEOUT: Mission timeout in seconds (default: 20)
+#   NUM_MISSIONS: Number of missions to run (default: 10)
+#
+# Requires: A running teleop instance (make run-teleop)
+
+set -e
+
+# Configuration
+TIMEOUT="${1:-20}"
+NUM_MISSIONS="${2:-10}"
+CONTAINER=""
+LOG_DIR="${LOG_DIR:-./logs}"
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+LOG_FILE="${LOG_DIR}/teleop_evaluation_${TIMESTAMP}.log"
+
+# Statistics tracking
+SUCCESSFUL=0
+FAILED=0
+declare -a MISSION_RESULTS
+declare -a MISSION_START_TIMES
+declare -a MISSION_END_TIMES
+declare -a MISSION_ERRORS
+
+# Find the running teleop container (strictly requires costnav-ros2-teleop)
+find_container() {
+    if docker ps --format '{{.Names}}' | grep -qx "costnav-ros2-teleop"; then
+        CONTAINER="costnav-ros2-teleop"
+        return 0
+    fi
+    return 1
+}
+
+# Log to both console and file
+log() {
+    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+    echo "$msg"
+    echo "$msg" >> "$LOG_FILE"
+}
+
+# Log only to file
+log_file() {
+    echo "$1" >> "$LOG_FILE"
+}
+
+# Execute ROS2 command in container
+ros2_exec() {
+    docker exec "$CONTAINER" bash -c "
+        if [ -f /opt/ros/jazzy/setup.bash ]; then source /opt/ros/jazzy/setup.bash; fi;
+        if [ -f /workspace/build_ws/install/local_setup.sh ]; then source /workspace/build_ws/install/local_setup.sh; fi;
+        if [ -f /isaac-sim/setup_ros_env.sh ]; then source /isaac-sim/setup_ros_env.sh; fi;
+        $1
+    " 2>&1
+}
+
+# Call start_mission service and wait for response
+start_mission() {
+    local result
+    result=$(ros2_exec "ros2 service call /start_mission std_srvs/srv/Trigger {}")
+    echo "$result"
+}
+
+# Query mission result from /get_mission_result service
+get_mission_result() {
+    local result
+    result=$(ros2_exec "ros2 service call /get_mission_result std_srvs/srv/Trigger {}")
+    echo "$result"
+}
+
+# Parse JSON field from mission result response
+# Usage: parse_result_field "result_string" "field_name"
+parse_result_field() {
+    local result_str="$1"
+    local field="$2"
+    # Extract the message field which contains JSON
+    local json_str
+    json_str=$(echo "$result_str" | grep -oP "message='[^']*'" | sed "s/message='//;s/'$//")
+    # Parse the specific field from JSON
+    echo "$json_str" | grep -oP "\"$field\":\s*[^,}]+" | sed "s/\"$field\":\s*//" | tr -d '"'
+}
+
+# Run a single mission with timeout and result checking
+run_mission() {
+    local mission_num=$1
+    local start_time
+    local end_time
+    local duration
+    local error_msg=""
+    local mission_result="FAILED"
+    local distance_to_goal=""
+
+    start_time=$(date +%s.%N)
+    MISSION_START_TIMES[$mission_num]=$(date '+%Y-%m-%d %H:%M:%S.%3N')
+
+    log "Mission $mission_num/$NUM_MISSIONS: Starting (timeout: ${TIMEOUT}s)"
+
+    # Call start_mission service
+    local service_result
+    service_result=$(start_mission 2>&1)
+
+    if echo "$service_result" | grep -q "success=True"; then
+        log "Mission $mission_num: Started, monitoring for completion..."
+
+        # Poll for mission completion or timeout
+        local poll_interval=1
+        local elapsed=0
+        local result_status="pending"
+
+        while [ "$elapsed" -lt "$TIMEOUT" ]; do
+            sleep "$poll_interval"
+            elapsed=$((elapsed + poll_interval))
+
+            # Query mission result
+            local result_response
+            result_response=$(get_mission_result 2>&1)
+
+            result_status=$(parse_result_field "$result_response" "result")
+            local in_progress
+            in_progress=$(parse_result_field "$result_response" "in_progress")
+            distance_to_goal=$(parse_result_field "$result_response" "distance_to_goal")
+
+            # Check if mission completed (success or failure)
+            if [ "$result_status" = "success" ]; then
+                mission_result="SUCCESS"
+                log "Mission $mission_num: Goal reached! Distance: ${distance_to_goal}m"
+                break
+            elif [ "$result_status" = "failure" ]; then
+                mission_result="FAILED"
+                error_msg="Timeout - distance to goal: ${distance_to_goal}m"
+                log "Mission $mission_num: Timeout! Distance: ${distance_to_goal}m"
+                break
+            fi
+
+            # Log progress every 5 seconds
+            if [ $((elapsed % 5)) -eq 0 ]; then
+                log "Mission $mission_num: In progress... (${elapsed}s elapsed, distance_to_goal: ${distance_to_goal}m)"
+            fi
+        done
+
+        # If we exited the loop due to our timeout (not mission manager's), mark as failed
+        if [ "$result_status" = "pending" ]; then
+            mission_result="FAILED"
+            error_msg="Evaluation timeout reached"
+            log "Mission $mission_num: Evaluation timeout!"
+        fi
+    else
+        error_msg="Service call failed: $service_result"
+        log "Mission $mission_num: ERROR - $error_msg"
+    fi
+
+    end_time=$(date +%s.%N)
+    MISSION_END_TIMES[$mission_num]=$(date '+%Y-%m-%d %H:%M:%S.%3N')
+
+    duration=$(echo "$end_time - $start_time" | bc)
+
+    if [ "$mission_result" = "SUCCESS" ]; then
+        SUCCESSFUL=$((SUCCESSFUL + 1))
+        MISSION_RESULTS[$mission_num]="SUCCESS"
+        log "Mission $mission_num: SUCCESS (duration: ${duration}s, distance: ${distance_to_goal}m)"
+    else
+        FAILED=$((FAILED + 1))
+        MISSION_RESULTS[$mission_num]="FAILED"
+        MISSION_ERRORS[$mission_num]="$error_msg"
+        log "Mission $mission_num: FAILED (duration: ${duration}s) - $error_msg"
+    fi
+}
+
+# Generate evaluation summary
+generate_summary() {
+    local success_rate
+    if [ "$NUM_MISSIONS" -gt 0 ]; then
+        success_rate=$(echo "scale=2; $SUCCESSFUL * 100 / $NUM_MISSIONS" | bc)
+    else
+        success_rate="0"
+    fi
+
+    log_file ""
+    log_file "============================================================"
+    log_file "TELEOP EVALUATION SUMMARY"
+    log_file "============================================================"
+    log_file "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
+    log_file "Configuration:"
+    log_file "  - Timeout per mission: ${TIMEOUT}s"
+    log_file "  - Total missions: $NUM_MISSIONS"
+    log_file "  - Container: $CONTAINER"
+    log_file ""
+    log_file "Results:"
+    log_file "  - Successful missions: $SUCCESSFUL"
+    log_file "  - Failed missions: $FAILED"
+    log_file "  - Success rate: ${success_rate}%"
+    log_file ""
+    log_file "Per-Mission Results:"
+    log_file "------------------------------------------------------------"
+
+    for i in $(seq 1 $NUM_MISSIONS); do
+        local result="${MISSION_RESULTS[$i]:-N/A}"
+        local start="${MISSION_START_TIMES[$i]:-N/A}"
+        local end="${MISSION_END_TIMES[$i]:-N/A}"
+        local error="${MISSION_ERRORS[$i]:-}"
+
+        log_file "Mission $i:"
+        log_file "  Status: $result"
+        log_file "  Start:  $start"
+        log_file "  End:    $end"
+        if [ -n "$error" ]; then
+            log_file "  Error:  $error"
+        fi
+    done
+
+    log_file "------------------------------------------------------------"
+    log_file "Log file: $LOG_FILE"
+    log_file "============================================================"
+}
+
+# Main execution
+main() {
+    # Create log directory if it doesn't exist
+    mkdir -p "$LOG_DIR"
+
+    # Initialize log file
+    log_file "============================================================"
+    log_file "TELEOP EVALUATION LOG"
+    log_file "Started: $(date '+%Y-%m-%d %H:%M:%S')"
+    log_file "============================================================"
+    log_file ""
+
+    echo ""
+    echo "=============================================="
+    echo "  Teleop Evaluation Script"
+    echo "=============================================="
+    echo "  Timeout:      ${TIMEOUT}s"
+    echo "  Missions:     $NUM_MISSIONS"
+    echo "  Log file:     $LOG_FILE"
+    echo "=============================================="
+    echo ""
+
+    # Find container (strictly requires make run-teleop)
+    if ! find_container; then
+        log "ERROR: 'make run-teleop' is not running."
+        log "Container 'costnav-ros2-teleop' not found."
+        log ""
+        log "Please start teleop first in a separate terminal:"
+        log "  make run-teleop"
+        exit 1
+    fi
+
+    log "Using container: $CONTAINER"
+    log ""
+    log "Starting evaluation of $NUM_MISSIONS missions..."
+    log ""
+
+    # Run all missions
+    for i in $(seq 1 $NUM_MISSIONS); do
+        run_mission "$i"
+        # Small delay between missions
+        if [ "$i" -lt "$NUM_MISSIONS" ]; then
+            sleep 2
+        fi
+    done
+
+    # Generate summary
+    generate_summary
+
+    # Print final summary to console
+    local success_rate
+    if [ "$NUM_MISSIONS" -gt 0 ]; then
+        success_rate=$(echo "scale=2; $SUCCESSFUL * 100 / $NUM_MISSIONS" | bc)
+    else
+        success_rate="0"
+    fi
+
+    echo ""
+    echo "=============================================="
+    echo "  Evaluation Complete"
+    echo "=============================================="
+    echo "  Successful: $SUCCESSFUL / $NUM_MISSIONS"
+    echo "  Failed:     $FAILED / $NUM_MISSIONS"
+    echo "  Success Rate: ${success_rate}%"
+    echo "  Log file:   $LOG_FILE"
+    echo "=============================================="
+}
+
+# Run main
+main


### PR DESCRIPTION

## 🎯 Purpose
- [x] New feature implementation
- [x] Bug fix
- [ ] Experimental code
- [ ] Documentation/configuration update
- [ ] Refactoring

## 📊 Changes

### New Features
- **Evaluation commands**: `make run-eval-nav2` and `make run-eval-teleop` for running consecutive missions with configurable timeout
- **Mission result tracking**: SUCCESS when robot is within 1m of goal, FAILURE on timeout
- **ROS2 service**: `/get_mission_result` returns mission status as JSON (result, distance_to_goal, in_progress)
- **Comprehensive logging**: Generates `./logs/{nav2,teleop}_evaluation_<timestamp>.log` with per-mission statistics

### Bug Fixes
- Fixed race condition where consecutive missions could inherit previous mission's SUCCESS status

### Files Added
- `scripts/eval_nav2.sh` - Nav2 evaluation script
- `scripts/eval_teleop.sh` - Teleop evaluation script
- `costnav_isaacsim/nav2_mission/mission_result_srv.py` - Service wrapper for mission results

### Files Modified
- `Makefile` - Added `run-eval-nav2` and `run-eval-teleop` targets with strict container checks
- `costnav_isaacsim/nav2_mission/mission_manager.py` - Added odometry tracking, distance calculation, result service, and mission result state machine
- `costnav_isaacsim/config/config_loader.py` - Added `goal_tolerance` config (default: 1.0m)

## 🧪 Testing
- [x] Verified locally
- [ ] Existing experiments reproducible
- [ ] New test cases added

### Usage
```bash
# Run nav2/teleop in one terminal
make run-nav2  # or make run-teleop

# Run evaluation in another terminal
make run-eval-nav2 TIMEOUT=60 NUM_MISSIONS=10
make run-eval-teleop TIMEOUT=60 NUM_MISSIONS=10