### PR TITLE
remove redundant pedestrian collider, set simple collider

### DIFF
--- a/costnav_isaacsim/people_manager.py
+++ b/costnav_isaacsim/people_manager.py
@@ -374,7 +374,7 @@ class PeopleManager:
                     continue
 
                 logger.debug(f"Using SkelRoot {skelroot.GetPrimPath()} for {root_path}")
-                self._apply_behavior_to_skelroot(skelroot, anim_graph, script_path, Utils)
+                self._apply_behavior_to_skelroot(skelroot, anim_graph, script_path)
                 skelroots.append(skelroot)
 
                 # Cache SkelRoot for stuck recovery
@@ -385,7 +385,6 @@ class PeopleManager:
             # Cache animation graph and script path for recovery
             self._cached_anim_graph = anim_graph
             self._cached_script_path = script_path
-            self._cached_utils = Utils
 
             self.initialized = True
             logger.info("PeopleManager initialization complete!")
@@ -607,7 +606,7 @@ class PeopleManager:
                 cleared.append((str(prim.GetPrimPath()), scripts))
         return cleared
 
-    def _apply_behavior_to_skelroot(self, skelroot_prim, anim_graph_prim, script_path, Utils):
+    def _apply_behavior_to_skelroot(self, skelroot_prim, anim_graph_prim, script_path):
         """Apply animation graph and behavior script to a SkelRoot prim."""
         omni.kit.commands.execute(
             "ApplyAnimationGraphAPICommand",
@@ -617,8 +616,6 @@ class PeopleManager:
         omni.kit.commands.execute("ApplyScriptingAPICommand", paths=[Sdf.Path(skelroot_prim.GetPrimPath())])
         attr = skelroot_prim.GetAttribute("omni:scripting:scripts")
         attr.Set([r"{}".format(script_path)])
-        Utils.add_colliders(skelroot_prim)
-        Utils.add_rigid_body_dynamics(skelroot_prim)
 
     def update(self, current_time: float) -> None:
         """Periodic update for stuck detection and recovery.
@@ -776,7 +773,6 @@ class PeopleManager:
                         skelroot,
                         self._cached_anim_graph,
                         self._cached_script_path,
-                        self._cached_utils,
                     )
                     logger.info(f"Re-applied behavior script for '{character_name}'")
                     return True

--- a/costnav_isaacsim/people_manager.py
+++ b/costnav_isaacsim/people_manager.py
@@ -233,7 +233,6 @@ class PeopleManager:
             try:
                 from omni.anim.people_api.settings import PeopleSettings
                 from omni.anim.people_api.scripts.character_setup import CharacterSetup, CharacterBehavior
-                from omni.anim.people_api.scripts.utils import Utils
 
                 logger.info("PeopleAPI modules imported successfully")
             except ImportError as e:


### PR DESCRIPTION
# 🔥 Fix: Update PeopleAPI submodule with simplified capsule colliders

## 🎯 Purpose
- [ ] New feature implementation
- [x] Bug fix
- [ ] Experimental code
- [ ] Documentation/configuration update
- [x] Refactoring

## 📊 Changes
- Updated `third_party/PeopleAPI` submodule from `ef9a562` → `99f3f7b`
  - Replaces complex `convexDecomposition` mesh colliders with simple capsule colliders
  - Prevents PhysX crashes when robot collides with animated human characters
- Modified `costnav_isaacsim/people_manager.py`
  - Removed duplicate collider/rigid body calls (now handled by CharacterSetup)
  - Cleaned up unused `Utils` parameter from `_apply_behavior_to_skelroot()`

## 🧪 Testing
<img width="1428" height="923" alt="image" src="https://github.com/user-attachments/assets/2742d379-8921-41cf-9afa-8ba2283ae4a8" />

- [x] Verified locally
- [x] Existing experiments reproducible
- [ ] New test cases added

## 🤔 Review Focus
Specific areas where feedback is needed:
- Capsule collider dimensions (1.7m height, 0.3m radius) - may need tuning
- Performance with large number of characters

## 📎 References
- PeopleAPI PR: https://github.com/worv-ai/PeopleAPI/pull/4
- Issue: PhysX crash during `simulation_context.step()` when robot contacts animated characters