### PR TITLE
🔥 Add: Robot fall detection with FAILURE_PHYSICALASSISTANCE termination state

### DIFF
--- a/costnav_isaacsim/nav2_mission/mission_manager.py
+++ b/costnav_isaacsim/nav2_mission/mission_manager.py
@@ -414,7 +414,7 @@ class MissionManager:
         tilt_angle = math.acos(min(1.0, max(-1.0, gz_body_z)))
 
         return tilt_angle > limit_angle
-    
+
     def _handle_set_timeout(self, msg):
         """Handle dynamic timeout configuration.
 

--- a/costnav_isaacsim/nav2_mission/mission_manager.py
+++ b/costnav_isaacsim/nav2_mission/mission_manager.py
@@ -62,7 +62,8 @@ class MissionResult(Enum):
 
     PENDING = "pending"  # Mission not yet started or in progress
     SUCCESS = "success"  # Robot reached goal within tolerance
-    FAILURE = "failure"  # Timeout reached before reaching goal
+    FAILURE_TIMEOUT = "failure_timeout"  # Timeout reached before reaching goal
+    FAILURE_PHYSICALASSISTANCE = "failure_physicalassistance"  # Robot fell down (bad orientation)
 
 
 class MissionManager:
@@ -162,6 +163,7 @@ class MissionManager:
 
         # Robot position tracking (from odom)
         self._robot_position = None  # (x, y, z) tuple
+        self._robot_orientation = None  # (x, y, z, w) quaternion tuple
 
         # Mission result tracking
         self._last_mission_result = MissionResult.PENDING
@@ -330,9 +332,11 @@ class MissionManager:
         self._last_mission_distance = None
 
     def _odom_callback(self, msg) -> None:
-        """Handle odometry messages for robot position tracking."""
+        """Handle odometry messages for robot position and orientation tracking."""
         pos = msg.pose.pose.position
         self._robot_position = (pos.x, pos.y, pos.z)
+        orient = msg.pose.pose.orientation
+        self._robot_orientation = (orient.x, orient.y, orient.z, orient.w)
 
     def _get_distance_to_goal(self) -> Optional[float]:
         """Calculate distance from robot to goal.
@@ -346,6 +350,39 @@ class MissionManager:
         rx, ry, _ = self._robot_position
         gx, gy = self._current_goal.x, self._current_goal.y
         return math.sqrt((rx - gx) ** 2 + (ry - gy) ** 2)
+
+    def _is_robot_fallen(self, limit_angle: float = 0.5) -> bool:
+        """Check if the robot has fallen based on orientation.
+
+        This checks if the robot's orientation deviates too much from upright.
+        It computes the angle between the robot's up vector (z-axis in body frame)
+        and the world up vector (gravity direction).
+
+        Args:
+            limit_angle: Maximum allowed tilt angle in radians (default: ~28.6 degrees).
+                        If the robot tilts beyond this, it's considered fallen.
+
+        Returns:
+            True if the robot has fallen, False otherwise.
+        """
+        if self._robot_orientation is None:
+            return False
+
+        qx, qy, _qz, _qw = self._robot_orientation
+
+        # Compute the z-component of the body z-axis projected to world z
+        # For a quaternion (qx, qy, qz, qw), this is:
+        # gz_body_z = 1 - 2 * (qx*qx + qy*qy)
+        # When robot is upright: gz_body_z = 1, tilt_angle = 0
+        # When robot is tilted 90°: gz_body_z = 0, tilt_angle = π/2
+        # When robot is upside down: gz_body_z = -1, tilt_angle = π
+        gz_body_z = 1.0 - 2.0 * (qx * qx + qy * qy)
+
+        # Compute tilt angle from upright (angle between body z and world z)
+        # gz_body_z is the cosine of the tilt angle
+        tilt_angle = math.acos(min(1.0, max(-1.0, gz_body_z)))
+
+        return tilt_angle > limit_angle
 
     def _handle_start_mission(self, _request, response):
         """Handle external mission start trigger."""
@@ -723,10 +760,11 @@ class MissionManager:
             self._state = MissionState.WAITING_FOR_COMPLETION
 
     def _step_waiting_for_completion(self):
-        """Wait for goal completion or timeout.
+        """Wait for goal completion, timeout, or robot fall.
 
         Success: Robot within goal_tolerance of goal position.
-        Failure: Timeout reached before reaching goal.
+        Failure (timeout): Timeout reached before reaching goal.
+        Failure (physical assistance): Robot fell down (bad orientation).
         """
         elapsed = self._get_current_time_seconds() - self._mission_start_time
         distance = self._get_distance_to_goal()
@@ -744,14 +782,26 @@ class MissionManager:
             )
             return
 
-        # Check for timeout (failure)
-        if self.mission_config.timeout is not None and elapsed >= self.mission_config.timeout:
+        # Check for robot fall (requires physical assistance)
+        if self._is_robot_fallen():
             self._mission_end_time = self._get_current_time_seconds()
-            self._last_mission_result = MissionResult.FAILURE
+            self._last_mission_result = MissionResult.FAILURE_PHYSICALASSISTANCE
             self._last_mission_distance = distance if distance is not None else -1.0
             self._state = MissionState.WAITING_FOR_START
             logger.info(
-                f"[FAILURE] Mission {self._current_mission} timed out! "
+                f"[FAILURE_PHYSICALASSISTANCE] Mission {self._current_mission} failed - robot fell down! "
+                f"Distance to goal: {distance:.2f}m, elapsed: {elapsed:.1f}s"
+            )
+            return
+
+        # Check for timeout (failure)
+        if self.mission_config.timeout is not None and elapsed >= self.mission_config.timeout:
+            self._mission_end_time = self._get_current_time_seconds()
+            self._last_mission_result = MissionResult.FAILURE_TIMEOUT
+            self._last_mission_distance = distance if distance is not None else -1.0
+            self._state = MissionState.WAITING_FOR_START
+            logger.info(
+                f"[FAILURE_TIMEOUT] Mission {self._current_mission} timed out! "
                 f"Distance to goal: {distance:.2f}m (needed: {self.mission_config.goal_tolerance}m), "
                 f"timeout: {self.mission_config.timeout}s"
             )

--- a/costnav_isaacsim/nav2_mission/mission_result_srv.py
+++ b/costnav_isaacsim/nav2_mission/mission_result_srv.py
@@ -6,11 +6,17 @@ in the response message field.
 
 Response format (JSON in message field):
 {
-    "result": "pending" | "success" | "failure",
+    "result": "pending" | "success" | "failure_timeout" | "failure_physicalassistance",
     "mission_number": int,
     "distance_to_goal": float,
     "in_progress": bool
 }
+
+Result values:
+- "pending": Mission not yet started or in progress
+- "success": Robot reached goal within tolerance
+- "failure_timeout": Timeout reached before reaching goal
+- "failure_physicalassistance": Robot fell down (bad orientation, requires physical assistance)
 """
 
 from std_srvs.srv import Trigger

--- a/scripts/eval_nav2.sh
+++ b/scripts/eval_nav2.sh
@@ -179,10 +179,10 @@ run_mission() {
                 mission_result="SUCCESS"
                 log "Mission $mission_num: Goal reached! Distance: ${distance_to_goal}m"
                 break
-            elif [ "$result_status" = "failure" ]; then
+            elif [[ "$result_status" == failure_* ]]; then
                 mission_result="FAILED"
-                error_msg="Timeout - distance to goal: ${distance_to_goal}m"
-                log "Mission $mission_num: Timeout! Distance: ${distance_to_goal}m"
+                error_msg="${result_status} - distance to goal: ${distance_to_goal}m"
+                log "Mission $mission_num: ${result_status}! Distance: ${distance_to_goal}m"
                 break
             fi
 

--- a/scripts/eval_teleop.sh
+++ b/scripts/eval_teleop.sh
@@ -179,10 +179,10 @@ run_mission() {
                 mission_result="SUCCESS"
                 log "Mission $mission_num: Goal reached! Distance: ${distance_to_goal}m"
                 break
-            elif [ "$result_status" = "failure" ]; then
+            elif [[ "$result_status" == failure_* ]]; then
                 mission_result="FAILED"
-                error_msg="Timeout - distance to goal: ${distance_to_goal}m"
-                log "Mission $mission_num: Timeout! Distance: ${distance_to_goal}m"
+                error_msg="${result_status} - distance to goal: ${distance_to_goal}m"
+                log "Mission $mission_num: ${result_status}! Distance: ${distance_to_goal}m"
                 break
             fi
 


### PR DESCRIPTION
## 🎯 Purpose
- [x] New feature implementation
- [ ] Bug fix
- [ ] Experimental code
- [ ] Documentation/configuration update
- [ ] Refactoring

## 📊 Changes

### Mission Manager (`costnav_isaacsim/nav2_mission/mission_manager.py`)
- Added `FAILURE_PHYSICALASSISTANCE` result for robot fall detection
- Renamed `FAILURE` to `FAILURE_TIMEOUT` for clarity
- Added robot orientation tracking from odometry messages
- Implemented `_is_robot_fallen()` method using quaternion-based tilt angle detection
- Updated `_step_waiting_for_completion()` to check for falls before timeout

### Service Documentation (`costnav_isaacsim/nav2_mission/mission_result_srv.py`)
- Updated JSON response format documentation with new result values

### Evaluation Scripts (`scripts/eval_nav2.sh`, `scripts/eval_teleop.sh`)
- Updated failure detection to use prefix matching (`failure_*`)
- Now correctly handles both `failure_timeout` and `failure_physicalassistance`

## 🧪 Testing
- [x] Verified locally
- [x] Fall detection triggers when robot flips over
- [x] Eval scripts correctly recognize new failure types
- [ ] New test cases added

## 🤔 Review Focus
- **Algorithm approach**: Fall detection uses tilt angle from quaternion (threshold: 0.5 rad ≈ 28.6°)
- **Edge cases**: Orientation tracking depends on odometry availability

## 📎 References