### PR TITLE
🔥 Add: Integrate `MAIS` injury modeling and metrics into mission management

### DIFF
--- a/costnav_isaacsim/config/__init__.py
+++ b/costnav_isaacsim/config/__init__.py
@@ -1,5 +1,11 @@
 """Configuration module for CostNav Isaac Sim launcher."""
 
-from .config_loader import FoodConfig, MissionConfig, load_mission_config
+from .config_loader import InjuryConfig, InjuryCostConfig, FoodConfig, MissionConfig, load_mission_config
 
-__all__ = ["FoodConfig", "MissionConfig", "load_mission_config"]
+__all__ = [
+    "FoodConfig",
+    "InjuryConfig",
+    "InjuryCostConfig",
+    "MissionConfig",
+    "load_mission_config",
+]

--- a/costnav_isaacsim/config/config_loader.py
+++ b/costnav_isaacsim/config/config_loader.py
@@ -70,6 +70,38 @@ class FoodConfig:
 
 
 @dataclass
+class InjuryCostConfig:
+    mais_0: float = 0.0
+    mais_1: float = 0.0
+    mais_2: float = 0.0
+    mais_3: float = 0.0
+    mais_4: float = 0.0
+    mais_5: float = 0.0
+    fatality: float = 0.0
+
+    def as_dict(self) -> dict:
+        return {
+            "mais_0": self.mais_0,
+            "mais_1": self.mais_1,
+            "mais_2": self.mais_2,
+            "mais_3": self.mais_3,
+            "mais_4": self.mais_4,
+            "mais_5": self.mais_5,
+            "fatality": self.fatality,
+        }
+
+
+@dataclass
+class InjuryConfig:
+    enabled: bool = True
+    method: str = "delta_v"
+    crash_mode: str = "all"
+    robot_height: Optional[float] = None
+    pedestrian_height: Optional[float] = None
+    costs: InjuryCostConfig = field(default_factory=InjuryCostConfig)
+
+
+@dataclass
 class MissionConfig:
     """Complete mission configuration."""
 
@@ -87,6 +119,7 @@ class MissionConfig:
     markers: MarkerConfig = field(default_factory=MarkerConfig)
     sampling: SamplingConfig = field(default_factory=SamplingConfig)
     food: FoodConfig = field(default_factory=FoodConfig)
+    injury: InjuryConfig = field(default_factory=InjuryConfig)
 
     @classmethod
     def from_dict(cls, data: dict) -> "MissionConfig":
@@ -98,6 +131,7 @@ class MissionConfig:
         markers_data = data.get("markers", {})
         sampling_data = data.get("sampling", {})
         food_data = data.get("food", {})
+        injury_data = data.get("injury", {})
 
         # Parse Nav2 config
         nav2_topics = nav2_data.get("topics", {})
@@ -149,6 +183,25 @@ class MissionConfig:
             spoilage_threshold=food_data.get("spoilage_threshold", 0.0),
         )
 
+        injury_costs_data = injury_data.get("costs", {})
+        injury_costs = InjuryCostConfig(
+            mais_0=injury_costs_data.get("mais_0", 0.0),
+            mais_1=injury_costs_data.get("mais_1", 0.0),
+            mais_2=injury_costs_data.get("mais_2", 0.0),
+            mais_3=injury_costs_data.get("mais_3", 0.0),
+            mais_4=injury_costs_data.get("mais_4", 0.0),
+            mais_5=injury_costs_data.get("mais_5", 0.0),
+            fatality=injury_costs_data.get("fatality", 0.0),
+        )
+        injury_config = InjuryConfig(
+            enabled=injury_data.get("enabled", True),
+            method=injury_data.get("method", "delta_v"),
+            crash_mode=injury_data.get("crash_mode", "all"),
+            robot_height=injury_data.get("robot_height"),
+            pedestrian_height=injury_data.get("pedestrian_height"),
+            costs=injury_costs,
+        )
+
         return cls(
             timeout=mission_data.get("timeout", 3600.0),
             goal_tolerance=mission_data.get("goal_tolerance", 1.0),
@@ -159,6 +212,7 @@ class MissionConfig:
             markers=markers_config,
             sampling=sampling_config,
             food=food_config,
+            injury=injury_config,
         )
 
     def to_dict(self) -> dict:

--- a/costnav_isaacsim/config/config_loader.py
+++ b/costnav_isaacsim/config/config_loader.py
@@ -96,6 +96,7 @@ class InjuryConfig:
     enabled: bool = True
     method: str = "delta_v"
     crash_mode: str = "all"
+    robot_mass: float = 50.0  # Robot mass in kg for delta-v = impulse / mass calculation
     robot_height: Optional[float] = None
     pedestrian_height: Optional[float] = None
     costs: InjuryCostConfig = field(default_factory=InjuryCostConfig)
@@ -197,6 +198,7 @@ class MissionConfig:
             enabled=injury_data.get("enabled", True),
             method=injury_data.get("method", "delta_v"),
             crash_mode=injury_data.get("crash_mode", "all"),
+            robot_mass=injury_data.get("robot_mass", 50.0),
             robot_height=injury_data.get("robot_height"),
             pedestrian_height=injury_data.get("pedestrian_height"),
             costs=injury_costs,

--- a/costnav_isaacsim/config/mission_config.yaml
+++ b/costnav_isaacsim/config/mission_config.yaml
@@ -100,6 +100,7 @@ injury:
   enabled: true
   method: "delta_v"
   crash_mode: "all"
+  robot_mass: 50.0  # Robot mass in kg for delta-v = impulse / mass calculation
   robot_height: null
   pedestrian_height: null
   costs:

--- a/costnav_isaacsim/config/mission_config.yaml
+++ b/costnav_isaacsim/config/mission_config.yaml
@@ -95,3 +95,18 @@ food:
 
   # Fraction of pieces that can be lost before mission fails (0.0 = no loss, 0.05 = 5% loss allowed)
   spoilage_threshold: 0.05
+
+injury:
+  enabled: true
+  method: "delta_v"
+  crash_mode: "all"
+  robot_height: null
+  pedestrian_height: null
+  costs:
+    mais_0: 380.0
+    mais_1: 8487.0
+    mais_2: 60464.0
+    mais_3: 261200.0
+    mais_4: 0.0  # Delivery robot context: MAIS 4+ not modeled (report covers motor vehicles)
+    mais_5: 0.0  # Delivery robot context: MAIS 4+ not modeled (report covers motor vehicles)
+    fatality: 0.0  # Delivery robot context: MAIS 4+ not modeled (report covers motor vehicles)


### PR DESCRIPTION
## 🎯 Purpose
- [x] New feature implementation
- [ ] Bug fix
- [ ] Experimental code
- [ ] Documentation/configuration update
- [ ] Refactoring

## 📊 Changes
- Add the `./costnav_isaacsim/nav2_mission/injury_model.py` for MAIS related coefs
- Update the `./costnav_isaacsim/nav2_mission/mission_manager.py` to compute injury costs by MAIS.
    - `delta-v` or `collision` -> `MAIS-{level}` -> injury costs
    - the injury related configurations are managed in `./costnav_isaacsim/config/mission_config.yaml` in injury field

## 🧪 Testing
- [x] Verified locally
- [ ] Existing experiments reproducible
- [ ] New test cases added

## 🤔 Review Focus
Specific areas where feedback is needed:
- Do check the results and its logging formats
    - Use the `make run-teleop SIM_ROBOT=segway_e1` or `make run-nav2 SIM_ROBOT=segway_e1` to run the simulator with teleoperation/Nav2(rule-based)
    - Check the mission results by starting the mission with `make run-eval-teleop` or `make run-nav2` and the logging results in the terminal of the simulations.

## 📎 References
- MAIS related docs.
