### PR TITLE
🔥 Fix: remove Isaac_sim_workspaces third-party dependency from ROS Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,7 +233,6 @@ costnav_isaaclab/source/costnav_isaaclab/20*/
 costnav_isaacsim/il_baselines/training/visualnav_transformer/checkpoints
 wandb/
 
-/build_ws/
 data/
 
 # Ignore assets (but keep README)

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "third_party/urban-sim"]
 	path = third_party/urban-sim
 	url = https://github.com/metadriverse/urban-sim.git
-[submodule "third_party/IsaacSim-ros_workspaces"]
-	path = third_party/IsaacSim-ros_workspaces
-	url = https://github.com/isaac-sim/IsaacSim-ros_workspaces.git
 # this is for quick development
 # automatically update to the Omniverse extension community
 # but it needs some times to sync

--- a/Dockerfile.ros
+++ b/Dockerfile.ros
@@ -6,17 +6,20 @@ FROM osrf/ros:jazzy-desktop
 ENV ROS_DISTRO=jazzy
 ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
 
-# Create workspace directory
-RUN mkdir -p /workspace/build_ws
+# Create workspace directory outside /workspace so bind-mounts don't shadow it
+RUN mkdir -p /opt/ros_ws
 
-# Copy the source packages to install dependencies via rosdep
-COPY third_party/IsaacSim-ros_workspaces/build_ws/jazzy/isaac_sim_ros_ws /workspace/build_ws
+# Build the isaac_sim_teleop_ros2 package into /opt/ros_ws
+COPY costnav_isaacsim/isaac_sim_teleop_ros2 /opt/ros_ws/src/isaac_sim_teleop_ros2
 
 # Install all dependencies using rosdep and additional packages for teleop
 RUN apt-get update && \
     rosdep update && \
-    rosdep install --from-paths /workspace/build_ws/src --ignore-src -r -y && \
+    rosdep install --from-paths /opt/ros_ws/src --ignore-src -r -y && \
     apt-get install -y \
+    ros-jazzy-navigation2 \
+    ros-jazzy-nav2-bringup \
+    ros-jazzy-pointcloud-to-laserscan \
     ros-jazzy-joy \
     ros-jazzy-teleop-twist-joy \
     ros-jazzy-image-transport-plugins \
@@ -26,17 +29,10 @@ RUN apt-get update && \
 # Set the default workspace directory
 WORKDIR /workspace
 
-# Copy the fastdds.xml configuration for multi-machine/docker communication
-COPY third_party/IsaacSim-ros_workspaces/jazzy_ws/fastdds.xml /workspace/build_ws/fastdds.xml
-ENV FASTRTPS_DEFAULT_PROFILES_FILE=/workspace/build_ws/fastdds.xml
-
-# Pre-build the isaac_sim_teleop_ros2 package into /workspace/build_ws
-COPY costnav_isaacsim/isaac_sim_teleop_ros2 /workspace/build_ws/src/isaac_sim_teleop_ros2
-
 # Build only the isaac_sim_teleop_ros2 package
 RUN . /opt/ros/jazzy/setup.sh && \
-    cd /workspace/build_ws && \
-    colcon build --packages-select isaac_sim_teleop_ros2
+    cd /opt/ros_ws && \
+    colcon build
 
 COPY docker/ros_entrypoint.sh /ros_entrypoint.sh
 RUN chmod +x /ros_entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-isaac-sim build-isaac-lab build-dev build-all fetch-third-party build-ros-ws build-ros2 build-vint run-ros2 run-isaac-sim run-isaac-sim-raw run-nav2 run-teleop run-vint start-mission start-mission-record run-rosbag stop-rosbag run-eval-nav2 run-eval-teleop run-eval-vint download-assets-omniverse download-assets-hf upload-assets-hf start-nucleus stop-nucleus
+.PHONY: build-isaac-sim build-isaac-lab build-dev build-all fetch-third-party build-ros2 build-vint run-ros2 run-isaac-sim run-isaac-sim-raw run-nav2 run-teleop run-vint start-mission start-mission-record run-rosbag stop-rosbag run-eval-nav2 run-eval-teleop run-eval-vint download-assets-omniverse download-assets-hf upload-assets-hf start-nucleus stop-nucleus
 
 # Load environment variables from .env file if it exists
 # Variables can still be overridden from command line
@@ -64,15 +64,6 @@ fetch-third-party:
 # ROS2 Workspace Build and Runtime Targets
 # =============================================================================
 
-# Build the Isaac Sim ROS workspace using build_ros.sh
-build-ros-ws:
-	@echo "==> Cleaning previous build_ws/$(ROS_DISTRO)..."
-	cd third_party/IsaacSim-ros_workspaces && \
-		docker run --rm -v $$(pwd)/build_ws:/build_ws ubuntu:$(UBUNTU_VERSION) rm -rf /build_ws/$(ROS_DISTRO)
-	@echo "==> Building ROS workspace for $(ROS_DISTRO) on Ubuntu $(UBUNTU_VERSION)..."
-	cd third_party/IsaacSim-ros_workspaces && ./build_ros.sh -d $(ROS_DISTRO) -v $(UBUNTU_VERSION)
-	@echo "==> Build complete!"
-
 # Build the ROS2 runtime Docker image
 build-ros2:
 	$(DOCKER_COMPOSE) --profile ros2 build ros2
@@ -113,10 +104,6 @@ run-nav2:
 	@if ! docker image inspect $(ISAAC_SIM_IMAGE) >/dev/null 2>&1; then \
 		echo "==> Missing Isaac Sim image ($(ISAAC_SIM_IMAGE)); building..."; \
 		$(MAKE) build-isaac-sim; \
-	fi
-	@if [ ! -d third_party/IsaacSim-ros_workspaces/build_ws/$(ROS_DISTRO)/isaac_sim_ros_ws ]; then \
-		echo "==> Missing ROS workspace for $(ROS_DISTRO); building..."; \
-		$(MAKE) build-ros-ws; \
 	fi
 	@if ! docker image inspect $(COSTNAV_ROS2_IMAGE) >/dev/null 2>&1; then \
 		echo "==> Missing ROS2 image ($(COSTNAV_ROS2_IMAGE)); building..."; \

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ make fetch-third-party # we use third-party submodules for reference or dependen
 
 ```bash
 cd CostNav
-make build-ros-ws # build third_party/IsaacSim-ros_workspaces
 make build-ros2
 make build-isaac-sim
 ```

--- a/costnav_isaacsim/README.md
+++ b/costnav_isaacsim/README.md
@@ -111,11 +111,6 @@ cd /path/to/CostNav
 # Build Isaac Sim image
 make build-isaac-sim
 
-# Build ROS2 workspace (required for Nav2)
-# Note: Clean up build_ws if errors occur
-# sudo rm -rf third_party/IsaacSim-ros_workspaces/build_ws
-make build-ros-ws
-
 # Build ROS2 runtime image
 make build-ros2
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 # Define a reusable block for ROS2 service configuration
-# Mounts the pre-built Isaac Sim ROS workspace from the host
-# The workspace should be built using: make build-ros-ws
 x-ros2-service: &ros2-service
   build:
     context: .

--- a/docker/ros_entrypoint.sh
+++ b/docker/ros_entrypoint.sh
@@ -4,8 +4,8 @@ set -e
 source /opt/ros/jazzy/setup.bash
 
 # Isaac Sim ROS2 packages
-if [ -f /workspace/build_ws/install/local_setup.bash ]; then
-    source /workspace/build_ws/install/local_setup.bash
+if [ -f /opt/ros_ws/install/local_setup.bash ]; then
+    source /opt/ros_ws/install/local_setup.bash
 fi
 
 exec "$@"

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -8,7 +8,6 @@ The folders in this directory mirror the external projects we draw inspiration o
 
 - `IsaacLab/` — reference checkout of NVIDIA's IsaacLab. Useful for reading upstream tasks, assets, and training utilities while building CostNav-specific environments.
 - `urban-sim/` — reference checkout of the Metadriverse urban simulator, used for the COCO robot configuration and related assets.
-- `IsaacSim-ros_workspaces/` — reference checkout of the Isaac Sim ROS workspaces. Contains two workspaces: `humble_ws` (ROS2 Humble) and `jazzy_ws` (ROS2 Jazzy). See [Isaac Sim documentation](https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_ros.html) for usage and installation instructions.
 - `PeopleAPI/` — reference checkout of the worv-ai PeopleAPI Isaac Sim extension for quick development while waiting on community extension updates.
 - `FoodAssets/` — reference checkout of the worv-ai FoodAssets Isaac Sim extension, used as a curated asset library for food-related scenes.
 


### PR DESCRIPTION
## 🎯 Purpose
- [ ] New feature implementation
- [x] Bug fix
- [ ] Experimental code
- [ ] Documentation/configuration update
- [x] Refactoring

## 🔁 Reproduce
```bash
make build-ros2
make run-nav2
make run-teleop
```

## 📊 Changes
- Removed `third_party/IsaacSim-ros_workspaces` submodule (no longer needed)
- Updated `Dockerfile.ros` to install Nav2 packages directly via apt instead of building from source
- Simplified `Makefile` by removing the `build-ros-ws` target
- Updated `docker/ros_entrypoint.sh` to source from `/opt/ros_ws`
- Cleaned up `.gitignore`, `.gitmodules`, `docker-compose.yml`, and documentation
- Increased overall Docker stability by removing unnecessary build steps

## 🧪 Testing
- [x] Verified locally
- [x] Existing experiments reproducible
- [ ] New test cases added

Verified `run-nav2` and `run-teleop` working fine without Isaac_sim_workspaces.

## 🤔 Review Focus
- Docker build stability without the third-party submodule
- ROS workspace sourcing path changes

## 📎 References
- N/A

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author