### PR TITLE
📝: add canvas third_party to the repo, change default value of missions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,6 +30,7 @@
 [submodule "third_party/diffusion_policy"]
 	path = third_party/diffusion_policy
 	url = https://github.com/real-stanford/diffusion_policy.git
+# private repository – skipped automatically for unauthorized users
 [submodule "third_party/canvas-costnav"]
 	path = third_party/canvas-costnav
 	url = https://github.com/MaumAI-Company/canvas-costnav

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,6 @@
 [submodule "third_party/diffusion_policy"]
 	path = third_party/diffusion_policy
 	url = https://github.com/real-stanford/diffusion_policy.git
+[submodule "third_party/canvas-costnav"]
+	path = third_party/canvas-costnav
+	url = https://github.com/MaumAI-Company/canvas-costnav

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Our key contributions are:
 
 You can find more details in our [technical report](https://arxiv.org/abs/2511.20216).
 
-The full cost benchmark formula with real world references is available in our google drive: https://drive.google.com/drive/folders/1j1MXm6NMkd6HHBwTJi_nSde7-shv4laX?usp=sharing 
+The full cost benchmark formula with real world references is available in our google drive: https://drive.google.com/drive/folders/1j1MXm6NMkd6HHBwTJi_nSde7-shv4laX?usp=sharing
 
 ## Getting Started
 
@@ -50,6 +50,8 @@ git clone https://github.com/worv-ai/CostNav.git
 cd CostNav
 make fetch-third-party # we use third-party submodules for reference or dependencies
 ```
+
+> **Note:** The `third_party/canvas-costnav` submodule is a **private repository**. If you don't have access, it will be skipped automatically during `make fetch-third-party`.
 
 ### 3. Configure environment variables
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ make build-ros2-torch
 MODEL_CHECKPOINT=checkpoints/baseline-vint.pth make run-vint
 
 # Terminal 2: Run evaluation
-make run-eval-vint TIMEOUT=169 NUM_MISSIONS=10
+make run-eval-vint TIMEOUT=241 NUM_MISSIONS=10
 ```
 
 For detailed IL training and evaluation documentation, see:

--- a/costnav_isaacsim/README.md
+++ b/costnav_isaacsim/README.md
@@ -268,7 +268,7 @@ make run-canvas
 make run-eval-canvas
 
 # Or with custom parameters (default: 169s timeout, 3 missions)
-make run-eval-canvas TIMEOUT=169 NUM_MISSIONS=10
+make run-eval-canvas TIMEOUT=241 NUM_MISSIONS=10
 ```
 
 Evaluation logs are saved to `./logs/canvas_evaluation_<timestamp>.log`.

--- a/costnav_isaacsim/costnav_isaacsim/src/costnav_isaacsim/config/config_loader.py
+++ b/costnav_isaacsim/costnav_isaacsim/src/costnav_isaacsim/config/config_loader.py
@@ -226,7 +226,7 @@ class MissionConfig:
 
     # Mission execution
     timeout: float = 3600.0  # 1 hour
-    goal_tolerance: float = 1.0  # Distance to goal for success (meters)
+    goal_tolerance: float = 2.0  # Distance to goal for success (meters)
 
     # Distance constraints
     min_distance: float = 5.0
@@ -392,7 +392,7 @@ class MissionConfig:
 
         return cls(
             timeout=mission_data.get("timeout", 3600.0),
-            goal_tolerance=mission_data.get("goal_tolerance", 1.0),
+            goal_tolerance=mission_data.get("goal_tolerance", 2.0),
             min_distance=distance_data.get("min", 5.0),
             max_distance=distance_data.get("max", 50.0),
             nav2=nav2_config,

--- a/costnav_isaacsim/costnav_isaacsim/tests/test_config_loader.py
+++ b/costnav_isaacsim/costnav_isaacsim/tests/test_config_loader.py
@@ -329,7 +329,7 @@ class TestMissionConfig:
         """Test MissionConfig default values."""
         config = MissionConfig()
         assert config.timeout == 3600.0
-        assert config.goal_tolerance == 1.0
+        assert config.goal_tolerance == 2.0
         assert config.min_distance == 5.0
         assert config.max_distance == 50.0
         # Verify sub-configs are created
@@ -969,7 +969,7 @@ class TestConfigUsageInMissionManager:
     def test_mission_manager_goal_tolerance(self):
         """Test MissionManager uses goal_tolerance."""
         config = load_mission_config()
-        assert config.goal_tolerance == 1.0
+        assert config.goal_tolerance == 2.0
 
     def test_mission_manager_timeout(self):
         """Test MissionManager uses timeout from YAML."""

--- a/costnav_isaacsim/il_evaluation/README.md
+++ b/costnav_isaacsim/il_evaluation/README.md
@@ -243,9 +243,9 @@ MODEL_CHECKPOINT=checkpoints/baseline-gnm.pth make run-gnm
 MODEL_CHECKPOINT=checkpoints/baseline-nomad.pth make run-nomad
 
 # Terminal 2: Run evaluation
-make run-eval-vint TIMEOUT=169 NUM_MISSIONS=10
-make run-eval-gnm TIMEOUT=169 NUM_MISSIONS=10
-make run-eval-nomad TIMEOUT=169 NUM_MISSIONS=10
+make run-eval-vint TIMEOUT=241 NUM_MISSIONS=10
+make run-eval-gnm TIMEOUT=241 NUM_MISSIONS=10
+make run-eval-nomad TIMEOUT=241 NUM_MISSIONS=10
 ```
 
 **Evaluation Parameters:**

--- a/costnav_isaacsim/nav2_params/segway_e1/navigation_params_tuned_true.yaml
+++ b/costnav_isaacsim/nav2_params/segway_e1/navigation_params_tuned_true.yaml
@@ -190,7 +190,7 @@ controller_server:
     general_goal_checker:
       stateful: True
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.9  # Slightly smaller than mission_manager goal_tolerance (1.0m)
+      xy_goal_tolerance: 1.8  # Slightly smaller than mission_manager goal_tolerance (2.0m)
       yaw_goal_tolerance: 0.25
 
     # Rotation Shim Controller - wraps DWB to enforce rotate-in-place for differential drive
@@ -234,7 +234,7 @@ controller_server:
       linear_granularity: 0.05
       angular_granularity: 0.025
       transform_tolerance: 0.2
-      xy_goal_tolerance: 0.9  # Slightly smaller than mission_manager goal_tolerance (1.0m)
+      xy_goal_tolerance: 1.8  # Slightly smaller than mission_manager goal_tolerance (2.0m)
       trans_stopped_velocity: 0.25
       short_circuit_trajectory_evaluation: True
       stateful: True

--- a/docs/canvas_integration_plan.md
+++ b/docs/canvas_integration_plan.md
@@ -239,7 +239,7 @@ make run-eval-canvas
 With custom parameters:
 
 ```bash
-make run-eval-canvas TIMEOUT=169 NUM_MISSIONS=20
+make run-eval-canvas TIMEOUT=241 NUM_MISSIONS=20
 ```
 
 ### Evaluation Parameters

--- a/scripts/fetch_third_party.sh
+++ b/scripts/fetch_third_party.sh
@@ -6,8 +6,36 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 echo "==> Syncing submodules"
 git -C "${ROOT_DIR}" submodule sync --recursive
 
+PRIVATE_SUBMODULES=("third_party/canvas-costnav")
+
 echo "==> Initializing top-level submodules"
-git -C "${ROOT_DIR}" submodule update --init
+# Build list of public submodules (exclude private ones)
+public_paths=()
+while IFS= read -r path; do
+  skip=false
+  for priv in "${PRIVATE_SUBMODULES[@]}"; do
+    if [[ "${path}" == "${priv}" ]]; then
+      skip=true
+      break
+    fi
+  done
+  if [[ "${skip}" == "false" ]]; then
+    public_paths+=("${path}")
+  fi
+done < <(git -C "${ROOT_DIR}" config -f .gitmodules --get-regexp '^submodule\..*\.path$' | awk '{print $2}')
+
+for path in "${public_paths[@]}"; do
+  git -C "${ROOT_DIR}" submodule update --init -- "${path}"
+done
+
+# Try to initialize private submodules; warn and continue on failure
+for priv in "${PRIVATE_SUBMODULES[@]}"; do
+  echo "==> Initializing private submodule ${priv} (requires access)"
+  if ! git -C "${ROOT_DIR}" submodule update --init -- "${priv}" 2>/dev/null; then
+    echo "WARNING: Could not initialize private submodule '${priv}'. Skipping."
+    echo "         Request access to the repository if you need this module."
+  fi
+done
 
 if [[ -d "${ROOT_DIR}/third_party/NavDP" ]]; then
   if git -C "${ROOT_DIR}/third_party/NavDP" ls-tree -d HEAD baselines/logoplanner/Pi3 >/dev/null 2>&1; then

--- a/scripts/fetch_third_party.sh
+++ b/scripts/fetch_third_party.sh
@@ -31,7 +31,7 @@ done
 # Try to initialize private submodules; warn and continue on failure
 for priv in "${PRIVATE_SUBMODULES[@]}"; do
   echo "==> Initializing private submodule ${priv} (requires access)"
-  if ! git -C "${ROOT_DIR}" submodule update --init -- "${priv}" 2>/dev/null; then
+  if ! GIT_TERMINAL_PROMPT=0 git -C "${ROOT_DIR}" submodule update --init -- "${priv}" 2>/dev/null; then
     echo "WARNING: Could not initialize private submodule '${priv}'. Skipping."
     echo "         Request access to the repository if you need this module."
   fi


### PR DESCRIPTION
## 🎯 Purpose                                                

  - New feature implementation
  - Bug fix
  - Experimental code
  - Documentation/configuration update
  - Refactoring

 ## 🔁 Reproduce

  # Canvas evaluation
```
  make run-canvas NUM_PEOPLE=20 SIM_ROBOT=segway_e1 FOOD=True
  make run-eval-canvas TIMEOUT=241 NUM_MISSIONS=10
```

  # IL baselines
  MODEL_CHECKPOINT=checkpoints/baseline-vint.pth make run-vint
  make run-eval-vint TIMEOUT=241 NUM_MISSIONS=10

  ## 📊 Changes

  Canvas integration (sketch-based navigation baseline)
  - Added third_party/canvas-costnav as a private git submodule (.gitmodules)
  - Updated scripts/fetch_third_party.sh to gracefully skip private submodules for
  unauthorized users

  Default value changes
  - goal_tolerance: 1.0 → 2.0 m (config_loader default + fallback)
  - xy_goal_tolerance: 0.9 → 1.8 m (Nav2 tuned params, kept slightly below mission
  manager threshold)
  - Evaluation timeout: 169 → 241 s across all docs and configs

  ## 🧪 Testing

  - Verified locally
  - Existing experiments reproducible
  - New test cases added

  ## 🤔 Review Focus

  - goal_tolerance 2.0 m / xy_goal_tolerance 1.8 m — confirm these values match
  desired evaluation criteria
  - Private submodule handling in fetch_third_party.sh — ensure
  GIT_TERMINAL_PROMPT=0 works across CI environments

## 📎 References